### PR TITLE
Add unit and E2E tests for PrskMusic and User modules

### DIFF
--- a/src/test/java/com/example/untitled/e2e/PrskMusicE2ETest.java
+++ b/src/test/java/com/example/untitled/e2e/PrskMusicE2ETest.java
@@ -1,0 +1,510 @@
+package com.example.untitled.e2e;
+
+import com.example.untitled.artist.dto.ArtistRequest;
+import com.example.untitled.artist.dto.ArtistResponse;
+import com.example.untitled.common.dto.ErrorResponse;
+import com.example.untitled.prskmusic.dto.OptionalPrskMusicRequest;
+import com.example.untitled.prskmusic.dto.PrskMusicListResponse;
+import com.example.untitled.prskmusic.dto.PrskMusicRequest;
+import com.example.untitled.prskmusic.dto.PrskMusicResponse;
+import com.example.untitled.prskmusic.enums.MusicType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("PrskMusic E2E Tests")
+class PrskMusicE2ETest extends E2ETestBase {
+
+    private static final String PRSK_MUSIC_PATH = "/prsk-music";
+    private static final String ARTISTS_PATH = "/artists";
+
+    // ========================================================================
+    // Helper Methods
+    // ========================================================================
+
+    private String uniqueTitle() {
+        return "Title-" + UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    private ArtistResponse createTestArtist() {
+        ArtistRequest request = new ArtistRequest();
+        request.setArtistName("Artist-" + UUID.randomUUID().toString().substring(0, 8));
+
+        ResponseEntity<ArtistResponse> response = restTemplate.postForEntity(
+                getBaseUrl() + ARTISTS_PATH,
+                request,
+                ArtistResponse.class
+        );
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        return response.getBody();
+    }
+
+    private PrskMusicResponse createPrskMusic(String title, Long artistId, MusicType musicType, String youtubeLink) {
+        PrskMusicRequest request = new PrskMusicRequest();
+        request.setTitle(title);
+        request.setArtistId(artistId);
+        request.setMusicType(musicType);
+        request.setYoutubeLink(youtubeLink);
+
+        ResponseEntity<PrskMusicResponse> response = restTemplate.postForEntity(
+                getBaseUrl() + PRSK_MUSIC_PATH,
+                request,
+                PrskMusicResponse.class
+        );
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        return response.getBody();
+    }
+
+    private PrskMusicResponse createPrskMusic(String title, Long artistId) {
+        return createPrskMusic(title, artistId, MusicType.ORIGINAL, "https://youtube.com/test");
+    }
+
+    // ========================================================================
+    // GET /prsk-music - List PrskMusic
+    // ========================================================================
+
+    @Nested
+    @DisplayName("GET /prsk-music")
+    class GetPrskMusicList {
+
+        @Test
+        @DisplayName("Success - returns list with created prsk music")
+        void getPrskMusicListSuccess() {
+            // Arrange: Create test data
+            ArtistResponse artist = createTestArtist();
+            createPrskMusic(uniqueTitle(), artist.getId(), MusicType.ORIGINAL, "https://youtube.com/1");
+            createPrskMusic(uniqueTitle(), artist.getId(), MusicType.THREE_D_MV, "https://youtube.com/2");
+
+            // Act
+            ResponseEntity<PrskMusicListResponse> response = restTemplate.getForEntity(
+                    getBaseUrl() + PRSK_MUSIC_PATH,
+                    PrskMusicListResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertNotNull(response.getBody().getItems());
+            assertNotNull(response.getBody().getMeta());
+            assertTrue(response.getBody().getItems().size() >= 2);
+        }
+
+        @Test
+        @DisplayName("Success - returns paginated results with page and limit params")
+        void getPrskMusicListSuccess_withPagination() {
+            // Arrange: Create 3 prsk music entries
+            ArtistResponse artist = createTestArtist();
+            for (int i = 0; i < 3; i++) {
+                createPrskMusic(uniqueTitle(), artist.getId());
+            }
+
+            // Act: Get page 1 with limit 2
+            ResponseEntity<PrskMusicListResponse> response = restTemplate.getForEntity(
+                    getBaseUrl() + PRSK_MUSIC_PATH + "?page=1&limit=2",
+                    PrskMusicListResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertNotNull(response.getBody().getMeta());
+            assertEquals(2, response.getBody().getMeta().getLimit());
+            assertTrue(response.getBody().getItems().size() <= 2);
+        }
+    }
+
+    // ========================================================================
+    // POST /prsk-music - Create PrskMusic
+    // ========================================================================
+
+    @Nested
+    @DisplayName("POST /prsk-music")
+    class CreatePrskMusic {
+
+        @Test
+        @DisplayName("Success - creates prsk music with all fields")
+        void createPrskMusicSuccess() {
+            // Arrange
+            ArtistResponse artist = createTestArtist();
+            PrskMusicRequest request = new PrskMusicRequest();
+            request.setTitle(uniqueTitle());
+            request.setArtistId(artist.getId());
+            request.setMusicType(MusicType.ORIGINAL);
+            request.setSpecially(true);
+            request.setLyricsName("Test Lyricist");
+            request.setMusicName("Test Composer");
+            request.setFeaturing("Feat.ABC");
+            request.setYoutubeLink("https://youtube.com/test");
+
+            // Act
+            ResponseEntity<PrskMusicResponse> response = restTemplate.postForEntity(
+                    getBaseUrl() + PRSK_MUSIC_PATH,
+                    request,
+                    PrskMusicResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.CREATED, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertNotNull(response.getBody().getId());
+            assertEquals(request.getTitle(), response.getBody().getTitle());
+            assertEquals(MusicType.ORIGINAL, response.getBody().getMusicType());
+            assertEquals(true, response.getBody().getSpecially());
+            assertEquals("Test Lyricist", response.getBody().getLyricsName());
+            assertNotNull(response.getBody().getAuditInfo());
+        }
+
+        @Test
+        @DisplayName("Success - creates prsk music with required fields only")
+        void createPrskMusicSuccess_withRequiredFieldsOnly() {
+            // Arrange
+            ArtistResponse artist = createTestArtist();
+            PrskMusicRequest request = new PrskMusicRequest();
+            request.setTitle(uniqueTitle());
+            request.setArtistId(artist.getId());
+            request.setMusicType(MusicType.THREE_D_MV);
+            request.setYoutubeLink("https://youtube.com/test");
+
+            // Act
+            ResponseEntity<PrskMusicResponse> response = restTemplate.postForEntity(
+                    getBaseUrl() + PRSK_MUSIC_PATH,
+                    request,
+                    PrskMusicResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.CREATED, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertNull(response.getBody().getLyricsName());
+            assertNull(response.getBody().getMusicName());
+            assertNull(response.getBody().getFeaturing());
+        }
+
+        @Test
+        @DisplayName("Error - 409 Conflict when title and musicType combination already exists")
+        void createPrskMusicError_withConflict() {
+            // Arrange: Create prsk music first
+            ArtistResponse artist = createTestArtist();
+            String existingTitle = uniqueTitle();
+            createPrskMusic(existingTitle, artist.getId(), MusicType.ORIGINAL, "https://youtube.com/test");
+
+            // Try to create another with the same title + musicType combination
+            PrskMusicRequest duplicateRequest = new PrskMusicRequest();
+            duplicateRequest.setTitle(existingTitle);
+            duplicateRequest.setArtistId(artist.getId());
+            duplicateRequest.setMusicType(MusicType.ORIGINAL);
+            duplicateRequest.setYoutubeLink("https://youtube.com/test2");
+
+            // Act
+            ResponseEntity<ErrorResponse> response = restTemplate.postForEntity(
+                    getBaseUrl() + PRSK_MUSIC_PATH,
+                    duplicateRequest,
+                    ErrorResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals(409, response.getBody().getStatusCode());
+        }
+
+        @Test
+        @DisplayName("Error - 400 Bad Request when title is blank")
+        void createPrskMusicError_withBadRequest_blankTitle() {
+            // Arrange
+            ArtistResponse artist = createTestArtist();
+            PrskMusicRequest request = new PrskMusicRequest();
+            request.setTitle("");
+            request.setArtistId(artist.getId());
+            request.setMusicType(MusicType.ORIGINAL);
+            request.setYoutubeLink("https://youtube.com/test");
+
+            // Act
+            ResponseEntity<ErrorResponse> response = restTemplate.postForEntity(
+                    getBaseUrl() + PRSK_MUSIC_PATH,
+                    request,
+                    ErrorResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals(400, response.getBody().getStatusCode());
+        }
+
+        @Test
+        @DisplayName("Error - 400 Bad Request when title is null")
+        void createPrskMusicError_withBadRequest_nullTitle() {
+            // Arrange
+            ArtistResponse artist = createTestArtist();
+            PrskMusicRequest request = new PrskMusicRequest();
+            request.setTitle(null);
+            request.setArtistId(artist.getId());
+            request.setMusicType(MusicType.ORIGINAL);
+            request.setYoutubeLink("https://youtube.com/test");
+
+            // Act
+            ResponseEntity<ErrorResponse> response = restTemplate.postForEntity(
+                    getBaseUrl() + PRSK_MUSIC_PATH,
+                    request,
+                    ErrorResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals(400, response.getBody().getStatusCode());
+        }
+
+        @Test
+        @DisplayName("Error - 400 Bad Request when title exceeds max length")
+        void createPrskMusicError_withBadRequest_titleTooLong() {
+            // Arrange: title max is 30 characters
+            ArtistResponse artist = createTestArtist();
+            PrskMusicRequest request = new PrskMusicRequest();
+            request.setTitle("T".repeat(31));
+            request.setArtistId(artist.getId());
+            request.setMusicType(MusicType.ORIGINAL);
+            request.setYoutubeLink("https://youtube.com/test");
+
+            // Act
+            ResponseEntity<ErrorResponse> response = restTemplate.postForEntity(
+                    getBaseUrl() + PRSK_MUSIC_PATH,
+                    request,
+                    ErrorResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        }
+    }
+
+    // ========================================================================
+    // PUT /prsk-music/{id} - Update PrskMusic
+    // ========================================================================
+
+    @Nested
+    @DisplayName("PUT /prsk-music/{id}")
+    class UpdatePrskMusic {
+
+        @Test
+        @DisplayName("Success - updates all fields")
+        void updatePrskMusicSuccess() {
+            // Arrange: Create prsk music
+            ArtistResponse artist = createTestArtist();
+            PrskMusicResponse created = createPrskMusic(uniqueTitle(), artist.getId(), MusicType.ORIGINAL, "https://youtube.com/old");
+
+            ArtistResponse newArtist = createTestArtist();
+            OptionalPrskMusicRequest updateRequest = new OptionalPrskMusicRequest();
+            updateRequest.setTitle(uniqueTitle());
+            updateRequest.setArtistId(newArtist.getId());
+            updateRequest.setMusicType(MusicType.THREE_D_MV);
+            updateRequest.setLyricsName("New Lyricist");
+            updateRequest.setYoutubeLink("https://youtube.com/new");
+
+            // Act
+            ResponseEntity<PrskMusicResponse> response = restTemplate.exchange(
+                    getBaseUrl() + PRSK_MUSIC_PATH + "/" + created.getId(),
+                    HttpMethod.PUT,
+                    new HttpEntity<>(updateRequest),
+                    PrskMusicResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals(created.getId(), response.getBody().getId());
+            assertEquals(updateRequest.getTitle(), response.getBody().getTitle());
+            assertEquals(MusicType.THREE_D_MV, response.getBody().getMusicType());
+            assertEquals("New Lyricist", response.getBody().getLyricsName());
+        }
+
+        @Test
+        @DisplayName("Success - updates partial fields (title only)")
+        void updatePrskMusicSuccess_partialUpdate() {
+            // Arrange: Create prsk music
+            ArtistResponse artist = createTestArtist();
+            PrskMusicResponse created = createPrskMusic(uniqueTitle(), artist.getId(), MusicType.ORIGINAL, "https://youtube.com/original");
+
+            OptionalPrskMusicRequest updateRequest = new OptionalPrskMusicRequest();
+            updateRequest.setTitle(uniqueTitle());
+
+            // Act
+            ResponseEntity<PrskMusicResponse> response = restTemplate.exchange(
+                    getBaseUrl() + PRSK_MUSIC_PATH + "/" + created.getId(),
+                    HttpMethod.PUT,
+                    new HttpEntity<>(updateRequest),
+                    PrskMusicResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals(updateRequest.getTitle(), response.getBody().getTitle());
+            // Original musicType should be preserved
+            assertEquals(MusicType.ORIGINAL, response.getBody().getMusicType());
+        }
+
+        @Test
+        @DisplayName("Error - 404 Not Found when ID does not exist")
+        void updatePrskMusicError_withNotFound() {
+            // Arrange
+            OptionalPrskMusicRequest updateRequest = new OptionalPrskMusicRequest();
+            updateRequest.setTitle(uniqueTitle());
+
+            // Act
+            ResponseEntity<ErrorResponse> response = restTemplate.exchange(
+                    getBaseUrl() + PRSK_MUSIC_PATH + "/" + Long.MAX_VALUE,
+                    HttpMethod.PUT,
+                    new HttpEntity<>(updateRequest),
+                    ErrorResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals(404, response.getBody().getStatusCode());
+        }
+
+        @Test
+        @DisplayName("Error - 409 Conflict when title and musicType combination already exists")
+        void updatePrskMusicError_withConflict() {
+            // Arrange: Create two prsk music entries
+            ArtistResponse artist = createTestArtist();
+            String existingTitle = uniqueTitle();
+            createPrskMusic(existingTitle, artist.getId(), MusicType.ORIGINAL, "https://youtube.com/existing");
+            PrskMusicResponse toUpdate = createPrskMusic(uniqueTitle(), artist.getId(), MusicType.THREE_D_MV, "https://youtube.com/update");
+
+            // Try to update second music with first music's title + musicType
+            OptionalPrskMusicRequest updateRequest = new OptionalPrskMusicRequest();
+            updateRequest.setTitle(existingTitle);
+            updateRequest.setMusicType(MusicType.ORIGINAL);
+
+            // Act
+            ResponseEntity<ErrorResponse> response = restTemplate.exchange(
+                    getBaseUrl() + PRSK_MUSIC_PATH + "/" + toUpdate.getId(),
+                    HttpMethod.PUT,
+                    new HttpEntity<>(updateRequest),
+                    ErrorResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals(409, response.getBody().getStatusCode());
+        }
+
+        @Test
+        @DisplayName("Error - 400 Bad Request when title exceeds max length")
+        void updatePrskMusicError_withBadRequest_titleTooLong() {
+            // Arrange: Create a prsk music
+            ArtistResponse artist = createTestArtist();
+            PrskMusicResponse created = createPrskMusic(uniqueTitle(), artist.getId());
+
+            OptionalPrskMusicRequest updateRequest = new OptionalPrskMusicRequest();
+            updateRequest.setTitle("T".repeat(31));
+
+            // Act
+            ResponseEntity<ErrorResponse> response = restTemplate.exchange(
+                    getBaseUrl() + PRSK_MUSIC_PATH + "/" + created.getId(),
+                    HttpMethod.PUT,
+                    new HttpEntity<>(updateRequest),
+                    ErrorResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        }
+    }
+
+    // ========================================================================
+    // DELETE /prsk-music/{id} - Delete PrskMusic
+    // ========================================================================
+
+    @Nested
+    @DisplayName("DELETE /prsk-music/{id}")
+    class DeletePrskMusic {
+
+        @Test
+        @DisplayName("Success - deletes prsk music and returns 204")
+        void deletePrskMusicSuccess() {
+            // Arrange: Create a prsk music
+            ArtistResponse artist = createTestArtist();
+            PrskMusicResponse created = createPrskMusic(uniqueTitle(), artist.getId());
+
+            // Act
+            ResponseEntity<Void> response = restTemplate.exchange(
+                    getBaseUrl() + PRSK_MUSIC_PATH + "/" + created.getId(),
+                    HttpMethod.DELETE,
+                    null,
+                    Void.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+
+            // Verify: Try to delete again should return 404 (soft-deleted)
+            ResponseEntity<ErrorResponse> verifyResponse = restTemplate.exchange(
+                    getBaseUrl() + PRSK_MUSIC_PATH + "/" + created.getId(),
+                    HttpMethod.DELETE,
+                    null,
+                    ErrorResponse.class
+            );
+            assertEquals(HttpStatus.NOT_FOUND, verifyResponse.getStatusCode());
+        }
+
+        @Test
+        @DisplayName("Error - 404 Not Found when ID does not exist")
+        void deletePrskMusicError_withNotFound() {
+            // Act
+            ResponseEntity<ErrorResponse> response = restTemplate.exchange(
+                    getBaseUrl() + PRSK_MUSIC_PATH + "/" + Long.MAX_VALUE,
+                    HttpMethod.DELETE,
+                    null,
+                    ErrorResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals(404, response.getBody().getStatusCode());
+        }
+
+        @Test
+        @DisplayName("Success - deleted prsk music does not appear in list")
+        void deletePrskMusicSuccess_notInList() {
+            // Arrange: Create and delete a prsk music
+            ArtistResponse artist = createTestArtist();
+            PrskMusicResponse created = createPrskMusic(uniqueTitle(), artist.getId());
+
+            restTemplate.exchange(
+                    getBaseUrl() + PRSK_MUSIC_PATH + "/" + created.getId(),
+                    HttpMethod.DELETE,
+                    null,
+                    Void.class
+            );
+
+            // Act: Get list
+            ResponseEntity<PrskMusicListResponse> listResponse = restTemplate.getForEntity(
+                    getBaseUrl() + PRSK_MUSIC_PATH,
+                    PrskMusicListResponse.class
+            );
+
+            // Assert: Deleted prsk music should not be in the list
+            assertEquals(HttpStatus.OK, listResponse.getStatusCode());
+            assertNotNull(listResponse.getBody());
+
+            boolean musicFound = listResponse.getBody().getItems().stream()
+                    .anyMatch(m -> m.getId().equals(created.getId()));
+            assertFalse(musicFound, "Deleted prsk music should not appear in list");
+        }
+    }
+}

--- a/src/test/java/com/example/untitled/e2e/UserE2ETest.java
+++ b/src/test/java/com/example/untitled/e2e/UserE2ETest.java
@@ -1,0 +1,409 @@
+package com.example.untitled.e2e;
+
+import com.example.untitled.common.dto.ErrorResponse;
+import com.example.untitled.user.dto.UserListResponse;
+import com.example.untitled.user.dto.UserRequest;
+import com.example.untitled.user.dto.UserResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("User E2E Tests")
+class UserE2ETest extends E2ETestBase {
+
+    private static final String USERS_PATH = "/users";
+
+    // ========================================================================
+    // Helper Methods
+    // ========================================================================
+
+    private String uniqueUserName() {
+        return "User-" + UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    private UserResponse createUser(String userName, String password) {
+        UserRequest request = new UserRequest();
+        request.setUserName(userName);
+        request.setPassword(password);
+
+        ResponseEntity<UserResponse> response = restTemplate.postForEntity(
+                getBaseUrl() + USERS_PATH,
+                request,
+                UserResponse.class
+        );
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        return response.getBody();
+    }
+
+    private UserResponse createUser(String userName) {
+        return createUser(userName, "testpassword");
+    }
+
+    // ========================================================================
+    // GET /users - List Users
+    // ========================================================================
+
+    @Nested
+    @DisplayName("GET /users")
+    class GetUsers {
+
+        @Test
+        @DisplayName("Success - returns list with created users")
+        void getUsersSuccess() {
+            // Arrange: Create test users
+            createUser(uniqueUserName());
+            createUser(uniqueUserName());
+
+            // Act
+            ResponseEntity<UserListResponse> response = restTemplate.getForEntity(
+                    getBaseUrl() + USERS_PATH,
+                    UserListResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertNotNull(response.getBody().getItems());
+            assertNotNull(response.getBody().getMetaInfo());
+            assertTrue(response.getBody().getItems().size() >= 2);
+        }
+
+        @Test
+        @DisplayName("Success - returns paginated results with page and limit params")
+        void getUsersSuccess_withPagination() {
+            // Arrange: Create 3 users
+            for (int i = 0; i < 3; i++) {
+                createUser(uniqueUserName());
+            }
+
+            // Act: Get page 1 with limit 2
+            ResponseEntity<UserListResponse> response = restTemplate.getForEntity(
+                    getBaseUrl() + USERS_PATH + "?page=1&limit=2",
+                    UserListResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertNotNull(response.getBody().getMetaInfo());
+            assertEquals(2, response.getBody().getMetaInfo().getLimit());
+            assertTrue(response.getBody().getItems().size() <= 2);
+        }
+    }
+
+    // ========================================================================
+    // POST /users - Create User
+    // ========================================================================
+
+    @Nested
+    @DisplayName("POST /users")
+    class CreateUser {
+
+        @Test
+        @DisplayName("Success - creates user with all fields")
+        void createUserSuccess() {
+            // Arrange
+            String userName = uniqueUserName();
+            UserRequest request = new UserRequest();
+            request.setUserName(userName);
+            request.setPassword("testpassword");
+
+            // Act
+            ResponseEntity<UserResponse> response = restTemplate.postForEntity(
+                    getBaseUrl() + USERS_PATH,
+                    request,
+                    UserResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.CREATED, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertNotNull(response.getBody().getId());
+            assertEquals(userName, response.getBody().getUserName());
+            assertNotNull(response.getBody().getAuditInfo());
+        }
+
+        @Test
+        @DisplayName("Error - 409 Conflict when userName already exists")
+        void createUserError_withConflict() {
+            // Arrange: Create a user first
+            String existingName = uniqueUserName();
+            createUser(existingName);
+
+            // Try to create another with the same userName
+            UserRequest duplicateRequest = new UserRequest();
+            duplicateRequest.setUserName(existingName);
+            duplicateRequest.setPassword("anotherpassword");
+
+            // Act
+            ResponseEntity<ErrorResponse> response = restTemplate.postForEntity(
+                    getBaseUrl() + USERS_PATH,
+                    duplicateRequest,
+                    ErrorResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals(409, response.getBody().getStatusCode());
+        }
+
+        @Test
+        @DisplayName("Error - 400 Bad Request when userName is blank")
+        void createUserError_withBadRequest_blankUserName() {
+            // Arrange
+            UserRequest request = new UserRequest();
+            request.setUserName("");
+            request.setPassword("testpassword");
+
+            // Act
+            ResponseEntity<ErrorResponse> response = restTemplate.postForEntity(
+                    getBaseUrl() + USERS_PATH,
+                    request,
+                    ErrorResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals(400, response.getBody().getStatusCode());
+        }
+
+        @Test
+        @DisplayName("Error - 400 Bad Request when userName is null")
+        void createUserError_withBadRequest_nullUserName() {
+            // Arrange
+            UserRequest request = new UserRequest();
+            request.setUserName(null);
+            request.setPassword("testpassword");
+
+            // Act
+            ResponseEntity<ErrorResponse> response = restTemplate.postForEntity(
+                    getBaseUrl() + USERS_PATH,
+                    request,
+                    ErrorResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals(400, response.getBody().getStatusCode());
+        }
+
+        @Test
+        @DisplayName("Error - 400 Bad Request when userName exceeds max length")
+        void createUserError_withBadRequest_userNameTooLong() {
+            // Arrange: userName max is 20 characters
+            UserRequest request = new UserRequest();
+            request.setUserName("U".repeat(21));
+            request.setPassword("testpassword");
+
+            // Act
+            ResponseEntity<ErrorResponse> response = restTemplate.postForEntity(
+                    getBaseUrl() + USERS_PATH,
+                    request,
+                    ErrorResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        }
+    }
+
+    // ========================================================================
+    // PUT /users/{id} - Update User
+    // ========================================================================
+
+    @Nested
+    @DisplayName("PUT /users/{id}")
+    class UpdateUser {
+
+        @Test
+        @DisplayName("Success - updates userName")
+        void updateUserSuccess() {
+            // Arrange: Create a user
+            String password = "testpassword";
+            UserResponse created = createUser(uniqueUserName(), password);
+
+            UserRequest updateRequest = new UserRequest();
+            updateRequest.setUserName(uniqueUserName());
+            updateRequest.setPassword(password);
+
+            // Act
+            ResponseEntity<UserResponse> response = restTemplate.exchange(
+                    getBaseUrl() + USERS_PATH + "/" + created.getId(),
+                    HttpMethod.PUT,
+                    new HttpEntity<>(updateRequest),
+                    UserResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals(created.getId(), response.getBody().getId());
+            assertEquals(updateRequest.getUserName(), response.getBody().getUserName());
+        }
+
+        @Test
+        @DisplayName("Error - 404 Not Found when ID does not exist")
+        void updateUserError_withNotFound() {
+            // Arrange
+            UserRequest updateRequest = new UserRequest();
+            updateRequest.setUserName(uniqueUserName());
+            updateRequest.setPassword("testpassword");
+
+            // Act
+            ResponseEntity<ErrorResponse> response = restTemplate.exchange(
+                    getBaseUrl() + USERS_PATH + "/" + Long.MAX_VALUE,
+                    HttpMethod.PUT,
+                    new HttpEntity<>(updateRequest),
+                    ErrorResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals(404, response.getBody().getStatusCode());
+        }
+
+        @Test
+        @DisplayName("Error - 401 Unauthorized when password is wrong")
+        void updateUserError_withUnauthorized_wrongPassword() {
+            // Arrange: Create a user with known password
+            UserResponse created = createUser(uniqueUserName(), "correctpassword");
+
+            UserRequest updateRequest = new UserRequest();
+            updateRequest.setUserName(uniqueUserName());
+            updateRequest.setPassword("wrongpassword");
+
+            // Act
+            ResponseEntity<ErrorResponse> response = restTemplate.exchange(
+                    getBaseUrl() + USERS_PATH + "/" + created.getId(),
+                    HttpMethod.PUT,
+                    new HttpEntity<>(updateRequest),
+                    ErrorResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals(401, response.getBody().getStatusCode());
+        }
+
+        @Test
+        @DisplayName("Error - 409 Conflict when userName already exists for another user")
+        void updateUserError_withConflict() {
+            // Arrange: Create two users
+            String existingName = uniqueUserName();
+            createUser(existingName);
+            UserResponse toUpdate = createUser(uniqueUserName(), "testpassword");
+
+            // Try to update second user with first user's userName
+            UserRequest updateRequest = new UserRequest();
+            updateRequest.setUserName(existingName);
+            updateRequest.setPassword("testpassword");
+
+            // Act
+            ResponseEntity<ErrorResponse> response = restTemplate.exchange(
+                    getBaseUrl() + USERS_PATH + "/" + toUpdate.getId(),
+                    HttpMethod.PUT,
+                    new HttpEntity<>(updateRequest),
+                    ErrorResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals(409, response.getBody().getStatusCode());
+        }
+    }
+
+    // ========================================================================
+    // DELETE /users/{id} - Delete User
+    // ========================================================================
+
+    @Nested
+    @DisplayName("DELETE /users/{id}")
+    class DeleteUser {
+
+        @Test
+        @DisplayName("Success - deletes user and returns 204")
+        void deleteUserSuccess() {
+            // Arrange: Create a user
+            UserResponse created = createUser(uniqueUserName());
+
+            // Act
+            ResponseEntity<Void> response = restTemplate.exchange(
+                    getBaseUrl() + USERS_PATH + "/" + created.getId(),
+                    HttpMethod.DELETE,
+                    null,
+                    Void.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+
+            // Verify: Try to delete again should return 404 (soft-deleted)
+            ResponseEntity<ErrorResponse> verifyResponse = restTemplate.exchange(
+                    getBaseUrl() + USERS_PATH + "/" + created.getId(),
+                    HttpMethod.DELETE,
+                    null,
+                    ErrorResponse.class
+            );
+            assertEquals(HttpStatus.NOT_FOUND, verifyResponse.getStatusCode());
+        }
+
+        @Test
+        @DisplayName("Error - 404 Not Found when ID does not exist")
+        void deleteUserError_withNotFound() {
+            // Act
+            ResponseEntity<ErrorResponse> response = restTemplate.exchange(
+                    getBaseUrl() + USERS_PATH + "/" + Long.MAX_VALUE,
+                    HttpMethod.DELETE,
+                    null,
+                    ErrorResponse.class
+            );
+
+            // Assert
+            assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals(404, response.getBody().getStatusCode());
+        }
+
+        @Test
+        @DisplayName("Success - deleted user does not appear in list")
+        void deleteUserSuccess_notInList() {
+            // Arrange: Create and delete a user
+            UserResponse created = createUser(uniqueUserName());
+
+            restTemplate.exchange(
+                    getBaseUrl() + USERS_PATH + "/" + created.getId(),
+                    HttpMethod.DELETE,
+                    null,
+                    Void.class
+            );
+
+            // Act: Get list
+            ResponseEntity<UserListResponse> listResponse = restTemplate.getForEntity(
+                    getBaseUrl() + USERS_PATH,
+                    UserListResponse.class
+            );
+
+            // Assert: Deleted user should not be in the list
+            assertEquals(HttpStatus.OK, listResponse.getStatusCode());
+            assertNotNull(listResponse.getBody());
+
+            boolean userFound = listResponse.getBody().getItems().stream()
+                    .anyMatch(u -> u.getId().equals(created.getId()));
+            assertFalse(userFound, "Deleted user should not appear in list");
+        }
+    }
+}

--- a/src/test/java/com/example/untitled/prskmusic/PrskMusicControllerTest.java
+++ b/src/test/java/com/example/untitled/prskmusic/PrskMusicControllerTest.java
@@ -1,0 +1,453 @@
+package com.example.untitled.prskmusic;
+
+import com.example.untitled.artist.Artist;
+import com.example.untitled.common.dto.ErrorDetails;
+import com.example.untitled.common.exception.DuplicationResourceException;
+import com.example.untitled.prskmusic.enums.MusicType;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.example.untitled.common.util.UtilsFunction.generateRandomString;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PrskMusicController.class)
+public class PrskMusicControllerTest {
+
+    @Autowired
+    private MockMvc mvcMock;
+
+    @MockitoBean
+    private PrskMusicService prskMusicService;
+
+    private PrskMusic createMockPrskMusic(Long id, String title, MusicType musicType, String youtubeLink) {
+        Artist artist = new Artist();
+        artist.setId(1L);
+        artist.setArtistName("Test Artist");
+        artist.setUnitName("Test Unit");
+        artist.setContent("Test Content");
+
+        PrskMusic prskMusic = new PrskMusic();
+        prskMusic.setId(id);
+        prskMusic.setTitle(title);
+        prskMusic.setArtist(artist);
+        prskMusic.setMusicType(musicType);
+        prskMusic.setYoutubeLink(youtubeLink);
+        return prskMusic;
+    }
+
+    /**
+     * POST /prsk-music : Response success
+     * プロセカ楽曲登録の正常系
+     */
+    @Test
+    public void registerPrskMusicSuccess() throws Exception {
+        PrskMusic mockPrskMusic = createMockPrskMusic(1L, "Test Title", MusicType.ORIGINAL, "https://youtube.com/test");
+        mockPrskMusic.setLyricsName("Test Lyricist");
+        mockPrskMusic.setMusicName("Test Composer");
+
+        when(prskMusicService.createPrskMusic(any())).thenReturn(mockPrskMusic);
+
+        String reqBody = """
+                {
+                    "title": "Test Title",
+                    "artistId": 1,
+                    "musicType": 0,
+                    "lyricsName": "Test Lyricist",
+                    "musicName": "Test Composer",
+                    "youtubeLink": "https://youtube.com/test"
+                }
+                """;
+
+        mvcMock.perform(post("/prsk-music")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.title").value("Test Title"))
+                .andExpect(jsonPath("$.musicType").value(0))
+                .andExpect(jsonPath("$.lyricsName").value("Test Lyricist"))
+                .andExpect(jsonPath("$.youtubeLink").value("https://youtube.com/test"));
+
+        verify(prskMusicService, times(1)).createPrskMusic(any());
+    }
+
+    /**
+     * POST /prsk-music : Response BadRequest
+     * titleのNull不可チェック
+     */
+    @Test
+    public void registerPrskMusicError_withBadRequest_TitleNull() throws Exception {
+        String reqBody = """
+                {
+                    "title": null,
+                    "artistId": 1,
+                    "musicType": 0,
+                    "youtubeLink": "https://youtube.com/test"
+                }
+                """;
+
+        mvcMock.perform(post("/prsk-music")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.details").exists())
+                .andExpect(jsonPath("$.details[0].field").value("title"));
+    }
+
+    /**
+     * POST /prsk-music : Response BadRequest
+     * バリデーションエラー（全フィールド文字数超過）
+     */
+    @Test
+    public void registerPrskMusicError_withBadRequest_LengthOver() throws Exception {
+        String ngTitle = generateRandomString(31);
+        String ngLyricsName = generateRandomString(51);
+        String ngMusicName = generateRandomString(51);
+        String ngFeaturing = generateRandomString(11);
+        String ngYoutubeLink = generateRandomString(101);
+
+        String reqBody = """
+                {
+                    "title": "%s",
+                    "artistId": 1,
+                    "musicType": 0,
+                    "lyricsName": "%s",
+                    "musicName": "%s",
+                    "featuring": "%s",
+                    "youtubeLink": "%s"
+                }
+                """.formatted(ngTitle, ngLyricsName, ngMusicName, ngFeaturing, ngYoutubeLink);
+
+        mvcMock.perform(post("/prsk-music")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.details").exists())
+                .andExpect(jsonPath("$.details[*].field",
+                        containsInAnyOrder("title", "lyricsName", "musicName", "featuring", "youtubeLink")));
+    }
+
+    /**
+     * POST /prsk-music : Conflict
+     * title + musicType の重複エラー
+     */
+    @Test
+    public void registerPrskMusicError_withConflict_AlreadyExist() throws Exception {
+        when(prskMusicService.createPrskMusic(any()))
+                .thenThrow(new DuplicationResourceException(
+                        "Conflict detected",
+                        List.of(new ErrorDetails("Title and MusicType", "Duplicate title and music type combination."))
+                ));
+
+        String reqBody = """
+                {
+                    "title": "Duplicate Title",
+                    "artistId": 1,
+                    "musicType": 0,
+                    "youtubeLink": "https://youtube.com/test"
+                }
+                """;
+
+        mvcMock.perform(post("/prsk-music")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.details").exists())
+                .andExpect(jsonPath("$.details[0].field").value("Title and MusicType"));
+    }
+
+    /**
+     * GET /prsk-music : Response success
+     * プロセカ楽曲一覧取得の正常系
+     */
+    @Test
+    public void getPrskMusicListSuccess() throws Exception {
+        PrskMusic music1 = createMockPrskMusic(1L, "Music 1", MusicType.ORIGINAL, "https://youtube.com/1");
+        PrskMusic music2 = createMockPrskMusic(2L, "Music 2", MusicType.THREE_D_MV, "https://youtube.com/2");
+
+        Page<PrskMusic> musicPage = new PageImpl<>(
+                Arrays.asList(music1, music2),
+                PageRequest.of(0, 20),
+                2
+        );
+
+        when(prskMusicService.getAllPrskMusic(0, 20, "title", "ASC")).thenReturn(musicPage);
+
+        mvcMock.perform(get("/prsk-music"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items", hasSize(2)))
+                .andExpect(jsonPath("$.items[0].id").value(1))
+                .andExpect(jsonPath("$.items[0].title").value("Music 1"))
+                .andExpect(jsonPath("$.items[1].id").value(2))
+                .andExpect(jsonPath("$.items[1].title").value("Music 2"))
+                .andExpect(jsonPath("$.meta.pageIndex").value(0))
+                .andExpect(jsonPath("$.meta.totalPages").value(1))
+                .andExpect(jsonPath("$.meta.totalItems").value(2))
+                .andExpect(jsonPath("$.meta.limit").value(20));
+
+        verify(prskMusicService, times(1)).getAllPrskMusic(0, 20, "title", "ASC");
+    }
+
+    /**
+     * GET /prsk-music : Response success with pagination parameters
+     * ページネーションパラメータを指定した一覧取得
+     */
+    @Test
+    public void getPrskMusicListSuccess_WithPaginationParams() throws Exception {
+        PrskMusic music1 = createMockPrskMusic(11L, "Music 11", MusicType.ORIGINAL, "https://youtube.com/11");
+        PrskMusic music2 = createMockPrskMusic(12L, "Music 12", MusicType.ORIGINAL, "https://youtube.com/12");
+        PrskMusic music3 = createMockPrskMusic(13L, "Music 13", MusicType.ORIGINAL, "https://youtube.com/13");
+        PrskMusic music4 = createMockPrskMusic(14L, "Music 14", MusicType.ORIGINAL, "https://youtube.com/14");
+        PrskMusic music5 = createMockPrskMusic(15L, "Music 15", MusicType.ORIGINAL, "https://youtube.com/15");
+
+        Page<PrskMusic> musicPage = new PageImpl<>(
+                List.of(music1, music2, music3, music4, music5),
+                PageRequest.of(1, 10),
+                15
+        );
+
+        when(prskMusicService.getAllPrskMusic(1, 10, "title", "ASC")).thenReturn(musicPage);
+
+        mvcMock.perform(get("/prsk-music")
+                        .param("page", "2")
+                        .param("limit", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items", hasSize(5)))
+                .andExpect(jsonPath("$.meta.pageIndex").value(1))
+                .andExpect(jsonPath("$.meta.totalPages").value(2))
+                .andExpect(jsonPath("$.meta.totalItems").value(15))
+                .andExpect(jsonPath("$.meta.limit").value(10));
+
+        verify(prskMusicService, times(1)).getAllPrskMusic(1, 10, "title", "ASC");
+    }
+
+    /**
+     * GET /prsk-music : BadRequest
+     * 不正なページネーションパラメータ（pageが0以下）
+     */
+    @Test
+    public void getPrskMusicListError_withBadRequest_InvalidPage() throws Exception {
+        mvcMock.perform(get("/prsk-music")
+                        .param("page", "0")
+                        .param("limit", "20"))
+                .andExpect(status().isBadRequest());
+    }
+
+    /**
+     * GET /prsk-music : BadRequest
+     * 不正なページネーションパラメータ（limitが範囲外）
+     */
+    @Test
+    public void getPrskMusicListError_withBadRequest_InvalidLimit() throws Exception {
+        mvcMock.perform(get("/prsk-music")
+                        .param("page", "1")
+                        .param("limit", "101"))
+                .andExpect(status().isBadRequest());
+
+        mvcMock.perform(get("/prsk-music")
+                        .param("page", "1")
+                        .param("limit", "0"))
+                .andExpect(status().isBadRequest());
+    }
+
+    /**
+     * PUT /prsk-music/{id} : Response success
+     * プロセカ楽曲情報更新の正常系
+     */
+    @Test
+    public void updatePrskMusicSuccess() throws Exception {
+        PrskMusic updatedMusic = createMockPrskMusic(1L, "Updated Title", MusicType.THREE_D_MV, "https://youtube.com/updated");
+        updatedMusic.setLyricsName("Updated Lyricist");
+
+        when(prskMusicService.updatePrskMusic(eq(1L), any())).thenReturn(updatedMusic);
+
+        String reqBody = """
+                {
+                    "title": "Updated Title",
+                    "musicType": 1,
+                    "lyricsName": "Updated Lyricist",
+                    "youtubeLink": "https://youtube.com/updated"
+                }
+                """;
+
+        mvcMock.perform(put("/prsk-music/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.title").value("Updated Title"))
+                .andExpect(jsonPath("$.musicType").value(1))
+                .andExpect(jsonPath("$.lyricsName").value("Updated Lyricist"));
+
+        verify(prskMusicService, times(1)).updatePrskMusic(eq(1L), any());
+    }
+
+    /**
+     * PUT /prsk-music/{id} : Response success with partial update
+     * 一部のフィールドのみ更新
+     */
+    @Test
+    public void updatePrskMusicSuccess_PartialUpdate() throws Exception {
+        PrskMusic updatedMusic = createMockPrskMusic(1L, "Updated Title", MusicType.ORIGINAL, "https://youtube.com/original");
+
+        when(prskMusicService.updatePrskMusic(eq(1L), any())).thenReturn(updatedMusic);
+
+        String reqBody = """
+                {
+                    "title": "Updated Title"
+                }
+                """;
+
+        mvcMock.perform(put("/prsk-music/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.title").value("Updated Title"))
+                .andExpect(jsonPath("$.musicType").value(0));
+
+        verify(prskMusicService, times(1)).updatePrskMusic(eq(1L), any());
+    }
+
+    /**
+     * PUT /prsk-music/{id} : NotFound
+     * 存在しないプロセカ楽曲IDを指定した場合
+     */
+    @Test
+    public void updatePrskMusicError_withNotFound() throws Exception {
+        when(prskMusicService.updatePrskMusic(eq(999L), any()))
+                .thenThrow(new EntityNotFoundException("Prsk music not found for id: 999"));
+
+        String reqBody = """
+                {
+                    "title": "Updated Title"
+                }
+                """;
+
+        mvcMock.perform(put("/prsk-music/999")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isNotFound());
+
+        verify(prskMusicService, times(1)).updatePrskMusic(eq(999L), any());
+    }
+
+    /**
+     * PUT /prsk-music/{id} : BadRequest
+     * バリデーションエラー（文字数超過）
+     */
+    @Test
+    public void updatePrskMusicError_withBadRequest_LengthOver() throws Exception {
+        String ngTitle = generateRandomString(31);
+
+        String reqBody = """
+                {
+                    "title": "%s"
+                }
+                """.formatted(ngTitle);
+
+        mvcMock.perform(put("/prsk-music/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.details").exists())
+                .andExpect(jsonPath("$.details[0].field").value("title"));
+
+        verify(prskMusicService, never()).updatePrskMusic(anyLong(), any());
+    }
+
+    /**
+     * PUT /prsk-music/{id} : Conflict
+     * title + musicType の重複エラー
+     */
+    @Test
+    public void updatePrskMusicError_withConflict_AlreadyExist() throws Exception {
+        when(prskMusicService.updatePrskMusic(eq(1L), any()))
+                .thenThrow(new DuplicationResourceException(
+                        "Conflict detected.",
+                        List.of(new ErrorDetails("Title and MusicType", "Duplicate title and music type combination."))
+                ));
+
+        String reqBody = """
+                {
+                    "title": "Duplicate Title",
+                    "musicType": 0
+                }
+                """;
+
+        mvcMock.perform(put("/prsk-music/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.details").exists())
+                .andExpect(jsonPath("$.details[0].field").value("Title and MusicType"));
+
+        verify(prskMusicService, times(1)).updatePrskMusic(eq(1L), any());
+    }
+
+    /**
+     * PUT /prsk-music/{id} : BadRequest
+     * 不正なIDパラメータ（0以下）
+     */
+    @Test
+    public void updatePrskMusicError_withBadRequest_InvalidId() throws Exception {
+        String reqBody = """
+                {
+                    "title": "Test Title"
+                }
+                """;
+
+        mvcMock.perform(put("/prsk-music/0")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isBadRequest());
+
+        verify(prskMusicService, never()).updatePrskMusic(anyLong(), any());
+    }
+
+    /**
+     * DELETE /prsk-music/{id} : Response success
+     * プロセカ楽曲削除の正常系
+     */
+    @Test
+    public void deletePrskMusicSuccess() throws Exception {
+        doNothing().when(prskMusicService).deletePrskMusic(1L);
+
+        mvcMock.perform(delete("/prsk-music/1"))
+                .andExpect(status().isNoContent());
+
+        verify(prskMusicService, times(1)).deletePrskMusic(1L);
+    }
+
+    /**
+     * DELETE /prsk-music/{id} : NotFound
+     * 存在しないプロセカ楽曲IDを指定した場合
+     */
+    @Test
+    public void deletePrskMusicError_withNotFound() throws Exception {
+        doThrow(new EntityNotFoundException("Prsk music not found for id: 999"))
+                .when(prskMusicService).deletePrskMusic(999L);
+
+        mvcMock.perform(delete("/prsk-music/999"))
+                .andExpect(status().isNotFound());
+
+        verify(prskMusicService, times(1)).deletePrskMusic(999L);
+    }
+}

--- a/src/test/java/com/example/untitled/prskmusic/PrskMusicServiceTest.java
+++ b/src/test/java/com/example/untitled/prskmusic/PrskMusicServiceTest.java
@@ -1,0 +1,441 @@
+package com.example.untitled.prskmusic;
+
+import com.example.untitled.artist.Artist;
+import com.example.untitled.artist.ArtistRepository;
+import com.example.untitled.common.exception.DuplicationResourceException;
+import com.example.untitled.prskmusic.dto.OptionalPrskMusicRequest;
+import com.example.untitled.prskmusic.dto.PrskMusicRequest;
+import com.example.untitled.prskmusic.enums.MusicType;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PrskMusicServiceTest {
+
+    @Mock
+    private PrskMusicRepository prskMusicRepository;
+
+    @Mock
+    private ArtistRepository artistRepository;
+
+    @InjectMocks
+    private PrskMusicService prskMusicService;
+
+    private Artist createArtist(Long id, String artistName) {
+        Artist artist = new Artist();
+        artist.setId(id);
+        artist.setArtistName(artistName);
+        artist.setUnitName("Test Unit");
+        artist.setContent("Test Content");
+        return artist;
+    }
+
+    private PrskMusic createPrskMusic(Long id, String title, MusicType musicType, Artist artist) {
+        PrskMusic prskMusic = new PrskMusic();
+        prskMusic.setId(id);
+        prskMusic.setTitle(title);
+        prskMusic.setArtist(artist);
+        prskMusic.setMusicType(musicType);
+        prskMusic.setYoutubeLink("https://youtube.com/test");
+        return prskMusic;
+    }
+
+    /**
+     * createPrskMusic : 正常系 - プロセカ楽曲が正常に作成される
+     */
+    @Test
+    public void createPrskMusicSuccess() {
+        Artist artist = createArtist(1L, "Test Artist");
+
+        PrskMusicRequest request = new PrskMusicRequest();
+        request.setTitle("Test Title");
+        request.setArtistId(1L);
+        request.setMusicType(MusicType.ORIGINAL);
+        request.setYoutubeLink("https://youtube.com/test");
+
+        PrskMusic createdMusic = createPrskMusic(1L, "Test Title", MusicType.ORIGINAL, artist);
+
+        when(prskMusicRepository.findByTitleAndMusicTypeAndIsDeleted("Test Title", MusicType.ORIGINAL, false))
+                .thenReturn(Optional.empty());
+        when(artistRepository.findByIdAndIsDeleted(1L, false)).thenReturn(Optional.of(artist));
+        when(prskMusicRepository.save(any(PrskMusic.class))).thenReturn(createdMusic);
+
+        PrskMusic result = prskMusicService.createPrskMusic(request);
+
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        assertEquals("Test Title", result.getTitle());
+        assertEquals(MusicType.ORIGINAL, result.getMusicType());
+
+        verify(prskMusicRepository, times(1)).findByTitleAndMusicTypeAndIsDeleted("Test Title", MusicType.ORIGINAL, false);
+        verify(artistRepository, times(1)).findByIdAndIsDeleted(1L, false);
+        verify(prskMusicRepository, times(1)).save(any(PrskMusic.class));
+    }
+
+    /**
+     * createPrskMusic : 異常系 - title + musicType が重複しており、例外をスローする
+     */
+    @Test
+    public void createPrskMusicError_withDuplication() {
+        Artist artist = createArtist(1L, "Test Artist");
+        PrskMusic existingMusic = createPrskMusic(1L, "Duplicate Title", MusicType.ORIGINAL, artist);
+
+        PrskMusicRequest request = new PrskMusicRequest();
+        request.setTitle("Duplicate Title");
+        request.setArtistId(1L);
+        request.setMusicType(MusicType.ORIGINAL);
+        request.setYoutubeLink("https://youtube.com/test");
+
+        when(prskMusicRepository.findByTitleAndMusicTypeAndIsDeleted("Duplicate Title", MusicType.ORIGINAL, false))
+                .thenReturn(Optional.of(existingMusic));
+
+        DuplicationResourceException exception = assertThrows(
+                DuplicationResourceException.class,
+                () -> prskMusicService.createPrskMusic(request)
+        );
+
+        assertNotNull(exception.getDetails());
+        assertEquals("Title and MusicType", exception.getDetails().get(0).getField());
+
+        verify(prskMusicRepository, times(1)).findByTitleAndMusicTypeAndIsDeleted("Duplicate Title", MusicType.ORIGINAL, false);
+        verify(prskMusicRepository, never()).save(any(PrskMusic.class));
+    }
+
+    /**
+     * createPrskMusic : 異常系 - アーティストが存在しない
+     */
+    @Test
+    public void createPrskMusicError_withArtistNotFound() {
+        PrskMusicRequest request = new PrskMusicRequest();
+        request.setTitle("Test Title");
+        request.setArtistId(999L);
+        request.setMusicType(MusicType.ORIGINAL);
+        request.setYoutubeLink("https://youtube.com/test");
+
+        when(prskMusicRepository.findByTitleAndMusicTypeAndIsDeleted("Test Title", MusicType.ORIGINAL, false))
+                .thenReturn(Optional.empty());
+        when(artistRepository.findByIdAndIsDeleted(999L, false)).thenReturn(Optional.empty());
+
+        EntityNotFoundException exception = assertThrows(
+                EntityNotFoundException.class,
+                () -> prskMusicService.createPrskMusic(request)
+        );
+
+        assertEquals("Artist not found for id: 999", exception.getMessage());
+
+        verify(prskMusicRepository, never()).save(any(PrskMusic.class));
+    }
+
+    /**
+     * getAllPrskMusic : 正常系 - プロセカ楽曲一覧を取得（ASC順）
+     */
+    @Test
+    public void getAllPrskMusicSuccess_ASC() {
+        Artist artist = createArtist(1L, "Test Artist");
+        PrskMusic music1 = createPrskMusic(1L, "Music A", MusicType.ORIGINAL, artist);
+        PrskMusic music2 = createPrskMusic(2L, "Music B", MusicType.THREE_D_MV, artist);
+
+        Page<PrskMusic> musicPage = new PageImpl<>(
+                Arrays.asList(music1, music2),
+                PageRequest.of(0, 20, Sort.by(Sort.Direction.ASC, "title")),
+                2
+        );
+
+        when(prskMusicRepository.findByIsDeleted(eq(false), any(Pageable.class))).thenReturn(musicPage);
+
+        Page<PrskMusic> result = prskMusicService.getAllPrskMusic(0, 20, "title", "ASC");
+
+        assertNotNull(result);
+        assertEquals(2, result.getTotalElements());
+        assertEquals(2, result.getContent().size());
+        assertEquals("Music A", result.getContent().get(0).getTitle());
+        assertEquals("Music B", result.getContent().get(1).getTitle());
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(prskMusicRepository, times(1)).findByIsDeleted(eq(false), pageableCaptor.capture());
+
+        Pageable capturedPageable = pageableCaptor.getValue();
+        assertEquals(0, capturedPageable.getPageNumber());
+        assertEquals(20, capturedPageable.getPageSize());
+        assertEquals(Sort.Direction.ASC, capturedPageable.getSort().getOrderFor("title").getDirection());
+    }
+
+    /**
+     * getAllPrskMusic : 正常系 - プロセカ楽曲一覧を取得（DESC順）
+     */
+    @Test
+    public void getAllPrskMusicSuccess_DESC() {
+        Artist artist = createArtist(1L, "Test Artist");
+        PrskMusic music1 = createPrskMusic(1L, "Music B", MusicType.ORIGINAL, artist);
+        PrskMusic music2 = createPrskMusic(2L, "Music A", MusicType.ORIGINAL, artist);
+
+        Page<PrskMusic> musicPage = new PageImpl<>(
+                Arrays.asList(music1, music2),
+                PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "title")),
+                2
+        );
+
+        when(prskMusicRepository.findByIsDeleted(eq(false), any(Pageable.class))).thenReturn(musicPage);
+
+        Page<PrskMusic> result = prskMusicService.getAllPrskMusic(0, 20, "title", "DESC");
+
+        assertNotNull(result);
+        assertEquals(2, result.getTotalElements());
+        assertEquals("Music B", result.getContent().get(0).getTitle());
+        assertEquals("Music A", result.getContent().get(1).getTitle());
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(prskMusicRepository, times(1)).findByIsDeleted(eq(false), pageableCaptor.capture());
+
+        Pageable capturedPageable = pageableCaptor.getValue();
+        assertEquals(Sort.Direction.DESC, capturedPageable.getSort().getOrderFor("title").getDirection());
+    }
+
+    /**
+     * getAllPrskMusic : 正常系 - 空のリストを返す
+     */
+    @Test
+    public void getAllPrskMusicSuccess_EmptyList() {
+        Page<PrskMusic> emptyPage = new PageImpl<>(
+                List.of(),
+                PageRequest.of(0, 20, Sort.by(Sort.Direction.ASC, "title")),
+                0
+        );
+
+        when(prskMusicRepository.findByIsDeleted(eq(false), any(Pageable.class))).thenReturn(emptyPage);
+
+        Page<PrskMusic> result = prskMusicService.getAllPrskMusic(0, 20, "title", "ASC");
+
+        assertNotNull(result);
+        assertEquals(0, result.getTotalElements());
+        assertTrue(result.getContent().isEmpty());
+
+        verify(prskMusicRepository, times(1)).findByIsDeleted(eq(false), any(Pageable.class));
+    }
+
+    /**
+     * updatePrskMusic : 正常系 - 全フィールド更新
+     */
+    @Test
+    public void updatePrskMusicSuccess_AllFields() {
+        Artist originalArtist = createArtist(1L, "Original Artist");
+        Artist newArtist = createArtist(2L, "New Artist");
+        PrskMusic existingMusic = createPrskMusic(1L, "Original Title", MusicType.ORIGINAL, originalArtist);
+
+        OptionalPrskMusicRequest request = new OptionalPrskMusicRequest();
+        request.setTitle("Updated Title");
+        request.setArtistId(2L);
+        request.setMusicType(MusicType.THREE_D_MV);
+        request.setLyricsName("New Lyricist");
+        request.setYoutubeLink("https://youtube.com/updated");
+
+        when(prskMusicRepository.findByIdAndIsDeleted(1L, false)).thenReturn(Optional.of(existingMusic));
+        when(prskMusicRepository.findByTitleAndMusicTypeAndIsDeleted("Updated Title", MusicType.THREE_D_MV, false))
+                .thenReturn(Optional.empty());
+        when(artistRepository.findByIdAndIsDeleted(2L, false)).thenReturn(Optional.of(newArtist));
+        when(prskMusicRepository.save(any(PrskMusic.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PrskMusic result = prskMusicService.updatePrskMusic(1L, request);
+
+        assertNotNull(result);
+        assertEquals("Updated Title", result.getTitle());
+        assertEquals(MusicType.THREE_D_MV, result.getMusicType());
+        assertEquals("New Artist", result.getArtist().getArtistName());
+        assertEquals("New Lyricist", result.getLyricsName());
+
+        verify(prskMusicRepository, times(1)).findByIdAndIsDeleted(1L, false);
+        verify(prskMusicRepository, times(1)).findByTitleAndMusicTypeAndIsDeleted("Updated Title", MusicType.THREE_D_MV, false);
+        verify(artistRepository, times(1)).findByIdAndIsDeleted(2L, false);
+        verify(prskMusicRepository, times(1)).save(any(PrskMusic.class));
+    }
+
+    /**
+     * updatePrskMusic : 正常系 - 一部フィールド更新（titleのみ）
+     */
+    @Test
+    public void updatePrskMusicSuccess_PartialFields() {
+        Artist artist = createArtist(1L, "Test Artist");
+        PrskMusic existingMusic = createPrskMusic(1L, "Original Title", MusicType.ORIGINAL, artist);
+        existingMusic.setLyricsName("Original Lyricist");
+
+        OptionalPrskMusicRequest request = new OptionalPrskMusicRequest();
+        request.setTitle("Updated Title");
+
+        when(prskMusicRepository.findByIdAndIsDeleted(1L, false)).thenReturn(Optional.of(existingMusic));
+        when(prskMusicRepository.findByTitleAndMusicTypeAndIsDeleted("Updated Title", MusicType.ORIGINAL, false))
+                .thenReturn(Optional.empty());
+        when(prskMusicRepository.save(any(PrskMusic.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PrskMusic result = prskMusicService.updatePrskMusic(1L, request);
+
+        assertNotNull(result);
+        assertEquals("Updated Title", result.getTitle());
+        assertEquals(MusicType.ORIGINAL, result.getMusicType());
+        assertEquals("Original Lyricist", result.getLyricsName());
+
+        verify(prskMusicRepository, times(1)).findByIdAndIsDeleted(1L, false);
+        verify(prskMusicRepository, times(1)).findByTitleAndMusicTypeAndIsDeleted("Updated Title", MusicType.ORIGINAL, false);
+        verify(prskMusicRepository, times(1)).save(any(PrskMusic.class));
+    }
+
+    /**
+     * updatePrskMusic : 正常系 - title と musicType が変更されない場合（重複チェックがスキップされる）
+     */
+    @Test
+    public void updatePrskMusicSuccess_SameTitleAndMusicType() {
+        Artist artist = createArtist(1L, "Test Artist");
+        PrskMusic existingMusic = createPrskMusic(1L, "Test Title", MusicType.ORIGINAL, artist);
+        existingMusic.setLyricsName("Original Lyricist");
+
+        OptionalPrskMusicRequest request = new OptionalPrskMusicRequest();
+        request.setTitle("Test Title");
+        request.setMusicType(MusicType.ORIGINAL);
+        request.setLyricsName("Updated Lyricist");
+
+        when(prskMusicRepository.findByIdAndIsDeleted(1L, false)).thenReturn(Optional.of(existingMusic));
+        when(prskMusicRepository.save(any(PrskMusic.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PrskMusic result = prskMusicService.updatePrskMusic(1L, request);
+
+        assertNotNull(result);
+        assertEquals("Test Title", result.getTitle());
+        assertEquals(MusicType.ORIGINAL, result.getMusicType());
+        assertEquals("Updated Lyricist", result.getLyricsName());
+
+        verify(prskMusicRepository, times(1)).findByIdAndIsDeleted(1L, false);
+        verify(prskMusicRepository, never()).findByTitleAndMusicTypeAndIsDeleted(anyString(), any(MusicType.class), eq(false));
+        verify(prskMusicRepository, times(1)).save(any(PrskMusic.class));
+    }
+
+    /**
+     * updatePrskMusic : 正常系 - 全フィールドが null の場合（元の値が維持される）
+     */
+    @Test
+    public void updatePrskMusicSuccess_AllFieldsNull() {
+        Artist artist = createArtist(1L, "Test Artist");
+        PrskMusic existingMusic = createPrskMusic(1L, "Original Title", MusicType.ORIGINAL, artist);
+        existingMusic.setLyricsName("Original Lyricist");
+
+        OptionalPrskMusicRequest request = new OptionalPrskMusicRequest();
+
+        when(prskMusicRepository.findByIdAndIsDeleted(1L, false)).thenReturn(Optional.of(existingMusic));
+        when(prskMusicRepository.save(any(PrskMusic.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PrskMusic result = prskMusicService.updatePrskMusic(1L, request);
+
+        assertNotNull(result);
+        assertEquals("Original Title", result.getTitle());
+        assertEquals(MusicType.ORIGINAL, result.getMusicType());
+        assertEquals("Original Lyricist", result.getLyricsName());
+
+        verify(prskMusicRepository, times(1)).findByIdAndIsDeleted(1L, false);
+        verify(prskMusicRepository, never()).findByTitleAndMusicTypeAndIsDeleted(anyString(), any(MusicType.class), eq(false));
+        verify(prskMusicRepository, times(1)).save(any(PrskMusic.class));
+    }
+
+    /**
+     * updatePrskMusic : 異常系 - プロセカ楽曲が見つからない
+     */
+    @Test
+    public void updatePrskMusicError_NotFound() {
+        OptionalPrskMusicRequest request = new OptionalPrskMusicRequest();
+        request.setTitle("Updated Title");
+
+        when(prskMusicRepository.findByIdAndIsDeleted(999L, false)).thenReturn(Optional.empty());
+
+        EntityNotFoundException exception = assertThrows(
+                EntityNotFoundException.class,
+                () -> prskMusicService.updatePrskMusic(999L, request)
+        );
+
+        assertEquals("Prsk music not found for id: 999", exception.getMessage());
+
+        verify(prskMusicRepository, times(1)).findByIdAndIsDeleted(999L, false);
+        verify(prskMusicRepository, never()).save(any(PrskMusic.class));
+    }
+
+    /**
+     * updatePrskMusic : 異常系 - title + musicType が重複
+     */
+    @Test
+    public void updatePrskMusicError_DuplicateTitleAndMusicType() {
+        Artist artist = createArtist(1L, "Test Artist");
+        PrskMusic existingMusic = createPrskMusic(1L, "Original Title", MusicType.ORIGINAL, artist);
+        PrskMusic duplicateMusic = createPrskMusic(2L, "Duplicate Title", MusicType.THREE_D_MV, artist);
+
+        OptionalPrskMusicRequest request = new OptionalPrskMusicRequest();
+        request.setTitle("Duplicate Title");
+        request.setMusicType(MusicType.THREE_D_MV);
+
+        when(prskMusicRepository.findByIdAndIsDeleted(1L, false)).thenReturn(Optional.of(existingMusic));
+        when(prskMusicRepository.findByTitleAndMusicTypeAndIsDeleted("Duplicate Title", MusicType.THREE_D_MV, false))
+                .thenReturn(Optional.of(duplicateMusic));
+
+        DuplicationResourceException exception = assertThrows(
+                DuplicationResourceException.class,
+                () -> prskMusicService.updatePrskMusic(1L, request)
+        );
+
+        assertNotNull(exception.getDetails());
+        assertEquals("Title and MusicType", exception.getDetails().get(0).getField());
+
+        verify(prskMusicRepository, times(1)).findByIdAndIsDeleted(1L, false);
+        verify(prskMusicRepository, times(1)).findByTitleAndMusicTypeAndIsDeleted("Duplicate Title", MusicType.THREE_D_MV, false);
+        verify(prskMusicRepository, never()).save(any(PrskMusic.class));
+    }
+
+    /**
+     * deletePrskMusic : 正常系 - プロセカ楽曲を論理削除
+     */
+    @Test
+    public void deletePrskMusicSuccess() {
+        Artist artist = createArtist(1L, "Test Artist");
+        PrskMusic existingMusic = createPrskMusic(1L, "Test Title", MusicType.ORIGINAL, artist);
+        existingMusic.setDeleted(false);
+
+        when(prskMusicRepository.findByIdAndIsDeleted(1L, false)).thenReturn(Optional.of(existingMusic));
+        when(prskMusicRepository.save(any(PrskMusic.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        prskMusicService.deletePrskMusic(1L);
+
+        assertTrue(existingMusic.isDeleted());
+
+        verify(prskMusicRepository, times(1)).findByIdAndIsDeleted(1L, false);
+        verify(prskMusicRepository, times(1)).save(existingMusic);
+    }
+
+    /**
+     * deletePrskMusic : 異常系 - プロセカ楽曲が見つからない
+     */
+    @Test
+    public void deletePrskMusicError_NotFound() {
+        when(prskMusicRepository.findByIdAndIsDeleted(999L, false)).thenReturn(Optional.empty());
+
+        EntityNotFoundException exception = assertThrows(
+                EntityNotFoundException.class,
+                () -> prskMusicService.deletePrskMusic(999L)
+        );
+
+        assertEquals("Prsk music not found for id: 999", exception.getMessage());
+
+        verify(prskMusicRepository, times(1)).findByIdAndIsDeleted(999L, false);
+        verify(prskMusicRepository, never()).save(any(PrskMusic.class));
+    }
+}

--- a/src/test/java/com/example/untitled/user/UserControllerTest.java
+++ b/src/test/java/com/example/untitled/user/UserControllerTest.java
@@ -1,0 +1,422 @@
+package com.example.untitled.user;
+
+import com.example.untitled.common.dto.ErrorDetails;
+import com.example.untitled.common.exception.DuplicationResourceException;
+import com.example.untitled.common.exception.UnauthorizedException;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.example.untitled.common.util.UtilsFunction.generateRandomString;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mvcMock;
+
+    @MockitoBean
+    private UserService userService;
+
+    private User createMockUser(Long id, String userName) {
+        User user = new User();
+        user.setId(id);
+        user.setUserName(userName);
+        user.setPassword("testpassword");
+        return user;
+    }
+
+    /**
+     * POST /users : Response success
+     * ユーザー登録の正常系
+     */
+    @Test
+    public void registerUserSuccess() throws Exception {
+        User mockUser = createMockUser(1L, "testuser");
+
+        when(userService.createUser(any())).thenReturn(mockUser);
+
+        String reqBody = """
+                {
+                    "userName": "testuser",
+                    "password": "testpassword"
+                }
+                """;
+
+        mvcMock.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.userName").value("testuser"));
+
+        verify(userService, times(1)).createUser(any());
+    }
+
+    /**
+     * POST /users : Response BadRequest
+     * userNameのNull不可チェック
+     */
+    @Test
+    public void registerUserError_withBadRequest_UserNameNull() throws Exception {
+        String reqBody = """
+                {
+                    "userName": null,
+                    "password": "testpassword"
+                }
+                """;
+
+        mvcMock.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.details").exists())
+                .andExpect(jsonPath("$.details[0].field").value("userName"));
+    }
+
+    /**
+     * POST /users : Response BadRequest
+     * バリデーションエラー（全フィールド文字数超過）
+     */
+    @Test
+    public void registerUserError_withBadRequest_LengthOver() throws Exception {
+        String ngUserName = generateRandomString(21);
+        String ngPassword = generateRandomString(21);
+
+        String reqBody = """
+                {
+                    "userName": "%s",
+                    "password": "%s"
+                }
+                """.formatted(ngUserName, ngPassword);
+
+        mvcMock.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.details").exists())
+                .andExpect(jsonPath("$.details[*].field", containsInAnyOrder("userName", "password")));
+    }
+
+    /**
+     * POST /users : Conflict
+     * ユーザー名の重複エラー
+     */
+    @Test
+    public void registerUserError_withConflict_AlreadyExist() throws Exception {
+        when(userService.createUser(any()))
+                .thenThrow(new DuplicationResourceException(
+                        "Conflict detected",
+                        List.of(new ErrorDetails("userName", "User name already exist: testuser"))
+                ));
+
+        String reqBody = """
+                {
+                    "userName": "testuser",
+                    "password": "testpassword"
+                }
+                """;
+
+        mvcMock.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.details").exists())
+                .andExpect(jsonPath("$.details[0].field").value("userName"));
+    }
+
+    /**
+     * GET /users : Response success
+     * ユーザー一覧取得の正常系
+     */
+    @Test
+    public void getUsersListSuccess() throws Exception {
+        User user1 = createMockUser(1L, "User 1");
+        User user2 = createMockUser(2L, "User 2");
+
+        Page<User> userPage = new PageImpl<>(
+                Arrays.asList(user1, user2),
+                PageRequest.of(0, 20),
+                2
+        );
+
+        when(userService.getAllUsers(0, 20, "userName", "ASC")).thenReturn(userPage);
+
+        mvcMock.perform(get("/users"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items", hasSize(2)))
+                .andExpect(jsonPath("$.items[0].id").value(1))
+                .andExpect(jsonPath("$.items[0].userName").value("User 1"))
+                .andExpect(jsonPath("$.items[1].id").value(2))
+                .andExpect(jsonPath("$.items[1].userName").value("User 2"))
+                .andExpect(jsonPath("$.metaInfo.pageIndex").value(0))
+                .andExpect(jsonPath("$.metaInfo.totalPages").value(1))
+                .andExpect(jsonPath("$.metaInfo.totalItems").value(2))
+                .andExpect(jsonPath("$.metaInfo.limit").value(20));
+
+        verify(userService, times(1)).getAllUsers(0, 20, "userName", "ASC");
+    }
+
+    /**
+     * GET /users : Response success with pagination parameters
+     * ページネーションパラメータを指定した一覧取得
+     */
+    @Test
+    public void getUsersListSuccess_WithPaginationParams() throws Exception {
+        User user1 = createMockUser(11L, "User 11");
+        User user2 = createMockUser(12L, "User 12");
+        User user3 = createMockUser(13L, "User 13");
+        User user4 = createMockUser(14L, "User 14");
+        User user5 = createMockUser(15L, "User 15");
+
+        Page<User> userPage = new PageImpl<>(
+                List.of(user1, user2, user3, user4, user5),
+                PageRequest.of(1, 10),
+                15
+        );
+
+        when(userService.getAllUsers(1, 10, "userName", "ASC")).thenReturn(userPage);
+
+        mvcMock.perform(get("/users")
+                        .param("page", "2")
+                        .param("limit", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items", hasSize(5)))
+                .andExpect(jsonPath("$.metaInfo.pageIndex").value(1))
+                .andExpect(jsonPath("$.metaInfo.totalPages").value(2))
+                .andExpect(jsonPath("$.metaInfo.totalItems").value(15))
+                .andExpect(jsonPath("$.metaInfo.limit").value(10));
+
+        verify(userService, times(1)).getAllUsers(1, 10, "userName", "ASC");
+    }
+
+    /**
+     * GET /users : BadRequest
+     * 不正なページネーションパラメータ（pageが0以下）
+     */
+    @Test
+    public void getUsersListError_withBadRequest_InvalidPage() throws Exception {
+        mvcMock.perform(get("/users")
+                        .param("page", "0")
+                        .param("limit", "20"))
+                .andExpect(status().isBadRequest());
+    }
+
+    /**
+     * GET /users : BadRequest
+     * 不正なページネーションパラメータ（limitが範囲外）
+     */
+    @Test
+    public void getUsersListError_withBadRequest_InvalidLimit() throws Exception {
+        mvcMock.perform(get("/users")
+                        .param("page", "1")
+                        .param("limit", "101"))
+                .andExpect(status().isBadRequest());
+
+        mvcMock.perform(get("/users")
+                        .param("page", "1")
+                        .param("limit", "0"))
+                .andExpect(status().isBadRequest());
+    }
+
+    /**
+     * PUT /users/{id} : Response success
+     * ユーザー情報更新の正常系
+     */
+    @Test
+    public void updateUserSuccess() throws Exception {
+        User updatedUser = createMockUser(1L, "updateduser");
+
+        when(userService.updateUser(eq(1L), any())).thenReturn(updatedUser);
+
+        String reqBody = """
+                {
+                    "userName": "updateduser",
+                    "password": "testpassword"
+                }
+                """;
+
+        mvcMock.perform(put("/users/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.userName").value("updateduser"));
+
+        verify(userService, times(1)).updateUser(eq(1L), any());
+    }
+
+    /**
+     * PUT /users/{id} : NotFound
+     * 存在しないユーザーIDを指定した場合
+     */
+    @Test
+    public void updateUserError_withNotFound() throws Exception {
+        when(userService.updateUser(eq(999L), any()))
+                .thenThrow(new EntityNotFoundException("User not found with id: 999"));
+
+        String reqBody = """
+                {
+                    "userName": "updateduser",
+                    "password": "testpassword"
+                }
+                """;
+
+        mvcMock.perform(put("/users/999")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isNotFound());
+
+        verify(userService, times(1)).updateUser(eq(999L), any());
+    }
+
+    /**
+     * PUT /users/{id} : Unauthorized
+     * パスワードが一致しない場合
+     */
+    @Test
+    public void updateUserError_withUnauthorized_WrongPassword() throws Exception {
+        when(userService.updateUser(eq(1L), any()))
+                .thenThrow(new UnauthorizedException(
+                        "Authentication failed",
+                        List.of(new ErrorDetails("password", "Invalid password"))
+                ));
+
+        String reqBody = """
+                {
+                    "userName": "testuser",
+                    "password": "wrongpassword"
+                }
+                """;
+
+        mvcMock.perform(put("/users/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.details").exists())
+                .andExpect(jsonPath("$.details[0].field").value("password"));
+
+        verify(userService, times(1)).updateUser(eq(1L), any());
+    }
+
+    /**
+     * PUT /users/{id} : BadRequest
+     * バリデーションエラー（文字数超過）
+     */
+    @Test
+    public void updateUserError_withBadRequest_LengthOver() throws Exception {
+        String ngUserName = generateRandomString(21);
+
+        String reqBody = """
+                {
+                    "userName": "%s",
+                    "password": "testpassword"
+                }
+                """.formatted(ngUserName);
+
+        mvcMock.perform(put("/users/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.details").exists())
+                .andExpect(jsonPath("$.details[0].field").value("userName"));
+
+        verify(userService, never()).updateUser(anyLong(), any());
+    }
+
+    /**
+     * PUT /users/{id} : Conflict
+     * ユーザー名の重複エラー
+     */
+    @Test
+    public void updateUserError_withConflict_AlreadyExist() throws Exception {
+        when(userService.updateUser(eq(1L), any()))
+                .thenThrow(new DuplicationResourceException(
+                        "Conflict detected",
+                        List.of(new ErrorDetails("userName", "User name already exist: duplicateuser"))
+                ));
+
+        String reqBody = """
+                {
+                    "userName": "duplicateuser",
+                    "password": "testpassword"
+                }
+                """;
+
+        mvcMock.perform(put("/users/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.details").exists())
+                .andExpect(jsonPath("$.details[0].field").value("userName"));
+
+        verify(userService, times(1)).updateUser(eq(1L), any());
+    }
+
+    /**
+     * PUT /users/{id} : BadRequest
+     * 不正なIDパラメータ（0以下）
+     */
+    @Test
+    public void updateUserError_withBadRequest_InvalidId() throws Exception {
+        String reqBody = """
+                {
+                    "userName": "testuser",
+                    "password": "testpassword"
+                }
+                """;
+
+        mvcMock.perform(put("/users/0")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqBody))
+                .andExpect(status().isBadRequest());
+
+        verify(userService, never()).updateUser(anyLong(), any());
+    }
+
+    /**
+     * DELETE /users/{id} : Response success
+     * ユーザー削除の正常系
+     */
+    @Test
+    public void deleteUserSuccess() throws Exception {
+        doNothing().when(userService).deleteUser(1L);
+
+        mvcMock.perform(delete("/users/1"))
+                .andExpect(status().isNoContent());
+
+        verify(userService, times(1)).deleteUser(1L);
+    }
+
+    /**
+     * DELETE /users/{id} : NotFound
+     * 存在しないユーザーIDを指定した場合
+     */
+    @Test
+    public void deleteUserError_withNotFound() throws Exception {
+        doThrow(new EntityNotFoundException("User not found for id: 999"))
+                .when(userService).deleteUser(999L);
+
+        mvcMock.perform(delete("/users/999"))
+                .andExpect(status().isNotFound());
+
+        verify(userService, times(1)).deleteUser(999L);
+    }
+}

--- a/src/test/java/com/example/untitled/user/UserServiceTest.java
+++ b/src/test/java/com/example/untitled/user/UserServiceTest.java
@@ -1,13 +1,23 @@
 package com.example.untitled.user;
 
 import com.example.untitled.common.exception.DuplicationResourceException;
+import com.example.untitled.common.exception.UnauthorizedException;
 import com.example.untitled.user.dto.UserRequest;
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -77,6 +87,280 @@ public class UserServiceTest {
         assertTrue(exception.getDetails().get(0).getMessage().contains("testuser"));
 
         verify(userRepository, times(1)).findByUserNameAndIsDeleted("testuser", false);
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    /**
+     * getAllUsers : 正常系 - ユーザー一覧を取得（ASC順）
+     */
+    @Test
+    public void getAllUsersSuccess_ASC() {
+        User user1 = new User();
+        user1.setId(1L);
+        user1.setUserName("User A");
+
+        User user2 = new User();
+        user2.setId(2L);
+        user2.setUserName("User B");
+
+        Page<User> userPage = new PageImpl<>(
+                Arrays.asList(user1, user2),
+                PageRequest.of(0, 20, Sort.by(Sort.Direction.ASC, "userName")),
+                2
+        );
+
+        when(userRepository.findByIsDeleted(eq(false), any(Pageable.class))).thenReturn(userPage);
+
+        Page<User> result = userService.getAllUsers(0, 20, "userName", "ASC");
+
+        assertNotNull(result);
+        assertEquals(2, result.getTotalElements());
+        assertEquals("User A", result.getContent().get(0).getUserName());
+        assertEquals("User B", result.getContent().get(1).getUserName());
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(userRepository, times(1)).findByIsDeleted(eq(false), pageableCaptor.capture());
+
+        Pageable capturedPageable = pageableCaptor.getValue();
+        assertEquals(0, capturedPageable.getPageNumber());
+        assertEquals(20, capturedPageable.getPageSize());
+        assertEquals(Sort.Direction.ASC, capturedPageable.getSort().getOrderFor("userName").getDirection());
+    }
+
+    /**
+     * getAllUsers : 正常系 - ユーザー一覧を取得（DESC順）
+     */
+    @Test
+    public void getAllUsersSuccess_DESC() {
+        User user1 = new User();
+        user1.setId(1L);
+        user1.setUserName("User B");
+
+        User user2 = new User();
+        user2.setId(2L);
+        user2.setUserName("User A");
+
+        Page<User> userPage = new PageImpl<>(
+                Arrays.asList(user1, user2),
+                PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "userName")),
+                2
+        );
+
+        when(userRepository.findByIsDeleted(eq(false), any(Pageable.class))).thenReturn(userPage);
+
+        Page<User> result = userService.getAllUsers(0, 20, "userName", "DESC");
+
+        assertNotNull(result);
+        assertEquals(2, result.getTotalElements());
+        assertEquals("User B", result.getContent().get(0).getUserName());
+        assertEquals("User A", result.getContent().get(1).getUserName());
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(userRepository, times(1)).findByIsDeleted(eq(false), pageableCaptor.capture());
+
+        Pageable capturedPageable = pageableCaptor.getValue();
+        assertEquals(Sort.Direction.DESC, capturedPageable.getSort().getOrderFor("userName").getDirection());
+    }
+
+    /**
+     * getAllUsers : 正常系 - 空のリストを返す
+     */
+    @Test
+    public void getAllUsersSuccess_EmptyList() {
+        Page<User> emptyPage = new PageImpl<>(
+                List.of(),
+                PageRequest.of(0, 20, Sort.by(Sort.Direction.ASC, "userName")),
+                0
+        );
+
+        when(userRepository.findByIsDeleted(eq(false), any(Pageable.class))).thenReturn(emptyPage);
+
+        Page<User> result = userService.getAllUsers(0, 20, "userName", "ASC");
+
+        assertNotNull(result);
+        assertEquals(0, result.getTotalElements());
+        assertTrue(result.getContent().isEmpty());
+
+        verify(userRepository, times(1)).findByIsDeleted(eq(false), any(Pageable.class));
+    }
+
+    /**
+     * updateUser : 正常系 - 新しいuserNameに変更
+     */
+    @Test
+    public void updateUserSuccess_NewUserName() {
+        User existingUser = new User();
+        existingUser.setId(1L);
+        existingUser.setUserName("originaluser");
+        existingUser.setPassword("testpassword");
+
+        UserRequest request = new UserRequest();
+        request.setUserName("newuser");
+        request.setPassword("testpassword");
+
+        when(userRepository.findByIdAndIsDeleted(1L, false)).thenReturn(Optional.of(existingUser));
+        when(userRepository.findByUserNameAndIsDeleted("newuser", false)).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        User result = userService.updateUser(1L, request);
+
+        assertNotNull(result);
+        assertEquals("newuser", result.getUserName());
+
+        verify(userRepository, times(1)).findByIdAndIsDeleted(1L, false);
+        verify(userRepository, times(1)).findByUserNameAndIsDeleted("newuser", false);
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+
+    /**
+     * updateUser : 正常系 - 同じuserNameで更新（自分自身のIDが一致するため重複チェック通過）
+     */
+    @Test
+    public void updateUserSuccess_SameUserName() {
+        User existingUser = new User();
+        existingUser.setId(1L);
+        existingUser.setUserName("testuser");
+        existingUser.setPassword("testpassword");
+
+        UserRequest request = new UserRequest();
+        request.setUserName("testuser");
+        request.setPassword("testpassword");
+
+        when(userRepository.findByIdAndIsDeleted(1L, false)).thenReturn(Optional.of(existingUser));
+        when(userRepository.findByUserNameAndIsDeleted("testuser", false)).thenReturn(Optional.of(existingUser));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        User result = userService.updateUser(1L, request);
+
+        assertNotNull(result);
+        assertEquals("testuser", result.getUserName());
+
+        verify(userRepository, times(1)).findByIdAndIsDeleted(1L, false);
+        verify(userRepository, times(1)).findByUserNameAndIsDeleted("testuser", false);
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+
+    /**
+     * updateUser : 異常系 - ユーザーが見つからない
+     */
+    @Test
+    public void updateUserError_NotFound() {
+        UserRequest request = new UserRequest();
+        request.setUserName("newuser");
+        request.setPassword("testpassword");
+
+        when(userRepository.findByIdAndIsDeleted(999L, false)).thenReturn(Optional.empty());
+
+        EntityNotFoundException exception = assertThrows(
+                EntityNotFoundException.class,
+                () -> userService.updateUser(999L, request)
+        );
+
+        assertEquals("User not found with id: 999", exception.getMessage());
+
+        verify(userRepository, times(1)).findByIdAndIsDeleted(999L, false);
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    /**
+     * updateUser : 異常系 - パスワードが一致しない
+     */
+    @Test
+    public void updateUserError_WrongPassword() {
+        User existingUser = new User();
+        existingUser.setId(1L);
+        existingUser.setUserName("testuser");
+        existingUser.setPassword("correctpassword");
+
+        UserRequest request = new UserRequest();
+        request.setUserName("testuser");
+        request.setPassword("wrongpassword");
+
+        when(userRepository.findByIdAndIsDeleted(1L, false)).thenReturn(Optional.of(existingUser));
+
+        UnauthorizedException exception = assertThrows(
+                UnauthorizedException.class,
+                () -> userService.updateUser(1L, request)
+        );
+
+        assertNotNull(exception.getDetails());
+        assertEquals("password", exception.getDetails().get(0).getField());
+
+        verify(userRepository, times(1)).findByIdAndIsDeleted(1L, false);
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    /**
+     * updateUser : 異常系 - userNameが他のユーザーと重複
+     */
+    @Test
+    public void updateUserError_DuplicateUserName() {
+        User existingUser = new User();
+        existingUser.setId(1L);
+        existingUser.setUserName("user1");
+        existingUser.setPassword("testpassword");
+
+        User anotherUser = new User();
+        anotherUser.setId(2L);
+        anotherUser.setUserName("existinguser2");
+
+        UserRequest request = new UserRequest();
+        request.setUserName("existinguser2");
+        request.setPassword("testpassword");
+
+        when(userRepository.findByIdAndIsDeleted(1L, false)).thenReturn(Optional.of(existingUser));
+        when(userRepository.findByUserNameAndIsDeleted("existinguser2", false))
+                .thenReturn(Optional.of(anotherUser));
+
+        DuplicationResourceException exception = assertThrows(
+                DuplicationResourceException.class,
+                () -> userService.updateUser(1L, request)
+        );
+
+        assertNotNull(exception.getDetails());
+        assertEquals("userName", exception.getDetails().get(0).getField());
+
+        verify(userRepository, times(1)).findByIdAndIsDeleted(1L, false);
+        verify(userRepository, times(1)).findByUserNameAndIsDeleted("existinguser2", false);
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    /**
+     * deleteUser : 正常系 - ユーザーを論理削除
+     */
+    @Test
+    public void deleteUserSuccess() {
+        User existingUser = new User();
+        existingUser.setId(1L);
+        existingUser.setUserName("testuser");
+        existingUser.setDeleted(false);
+
+        when(userRepository.findByIdAndIsDeleted(1L, false)).thenReturn(Optional.of(existingUser));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        userService.deleteUser(1L);
+
+        assertTrue(existingUser.isDeleted());
+
+        verify(userRepository, times(1)).findByIdAndIsDeleted(1L, false);
+        verify(userRepository, times(1)).save(existingUser);
+    }
+
+    /**
+     * deleteUser : 異常系 - ユーザーが見つからない
+     */
+    @Test
+    public void deleteUserError_NotFound() {
+        when(userRepository.findByIdAndIsDeleted(999L, false)).thenReturn(Optional.empty());
+
+        EntityNotFoundException exception = assertThrows(
+                EntityNotFoundException.class,
+                () -> userService.deleteUser(999L)
+        );
+
+        assertEquals("User not found for id: 999", exception.getMessage());
+
+        verify(userRepository, times(1)).findByIdAndIsDeleted(999L, false);
         verify(userRepository, never()).save(any(User.class));
     }
 }


### PR DESCRIPTION
<!-- prettier-ignore-start -->
![PR-Header](https://capsule-render.vercel.app/api?type=slice&height=39&color=0:33aaee,100:bbdd22&section=header&reversal=false)

### 🌸 作業概要 🌸

PrskMusic・User モジュールのテストが未実装だったため、Artist モジュールのテスト実装を参考に単体テスト（Controller・Service）および E2E テストを追加。

### 💫 追加/変更/修正内容 🍀

- `PrskMusicControllerTest` 追加（16 テストケース）
  - POST /prsk-musics, GET /prsk-musics, PUT /prsk-musics/{id}, DELETE /prsk-musics/{id} の正常系・異常系
- `PrskMusicServiceTest` 追加（14 テストケース）
  - createPrskMusic, getAllPrskMusic, updatePrskMusic, deletePrskMusic の正常系・異常系
- `PrskMusicE2ETest` 追加（16 テストケース）
  - 実 DB を使った E2E テスト（Docker PostgreSQL 使用）
- `UserControllerTest` 追加（16 テストケース）
  - POST /users, GET /users, PUT /users/{id}, DELETE /users/{id} の正常系・異常系
- `UserServiceTest` 拡張（2 → 12 テストケース）
  - getAllUsers, updateUser, deleteUser のテストケースを追加
- `UserE2ETest` 追加（14 テストケース）
  - 実 DB を使った E2E テスト（Docker PostgreSQL 使用）

### 🎤 確認事項 🎪

- [x] branch名はどんな作業を行ったかわかる命名にしたか(ex.20250831_add_readme)
- [ ] Dev環境にデプロイしての動作確認実施したか
- [ ] 影響確認を行ったか
- [ ] APIドキュメントを更新した際にはビルドして確認したか
- [ ] テストの実施
  - [x] 新規API作成時、単体テスト追加をしたか
  - [x] 新規API作成時、E2Eテスト追加をしたか
  - [x] ローカルにて単体テストの実施をしたか（`./gradlew testUnit` にて全テスト PASS 確認済み）
  - [ ] ローカルにてE2Eテストの実施をしたか
- [ ] AIによるレビューの実施を行い、以下の確認をしたか
  - [ ] 指摘事項の妥当性の確認
  - [ ] 根拠の確認・調査
  - [ ] 指摘事項の修正
  - [ ] 再レビューの実施

#### 🎸 AI指摘事項 🎹

<Details><Summary>Review by ClaudeAI and ChatGPT</Summary>

\`\`\`ts
本PRでは指摘事項なし
\`\`\`

</Details>

### 💻 評価項目 🆚

- `./gradlew testUnit` を実行し、全テストが PASS することを確認
  - PrskMusicControllerTest: 16 件 PASS
  - PrskMusicServiceTest: 14 件 PASS
  - UserControllerTest: 16 件 PASS
  - UserServiceTest: 12 件 PASS

### 🎵 備考 💚 Y(_ﾟ□ﾟ_) < (あれば)

- E2E テストは Docker（PostgreSQL）が必要なため、ローカル実行は未確認。CI/CD（`testE2e` ワークフロー）での確認を推奨。
- `PrskMusicControllerTest` では `PrskMusicResponse.from()` 内部で `prskMusic.getArtist().isDeleted()` が呼ばれるため、モック PrskMusic に Artist オブジェクトを埋め込む必要があった。

![PR-Footer](https://capsule-render.vercel.app/api?type=slice&height=39&color=0:33aaee,100:bbdd22&section=footer&reversal=false)
<!-- prettier-ignore-end -->